### PR TITLE
Add feature type to match GeoJSON spec

### DIFF
--- a/maps/serializers.py
+++ b/maps/serializers.py
@@ -18,7 +18,7 @@ def feature_serialize_geojson(queryset, more, properties=["category", "id"]):
         local_properties['uuid'] = str(uuid4())
         # Filter out any defaulted / not set locations
         if obj.location != 'POINT (0 0)':
-            feature = {'geometry': json.loads(obj.location.geojson), 'properties': local_properties}
+            feature = {'geometry': json.loads(obj.location.geojson), 'properties': local_properties, 'type': 'Feature'}
 
         serialized_data.append(feature)
 


### PR DESCRIPTION
Some map providers will error out when trying to render a GeoJSON layer that doesn't have `type: 'Feature'` in each of the feature objects in a FeatureCollection